### PR TITLE
Workflow updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,13 @@
 name: Build
-on: [pull_request, push]
+on:
+  push:
+    branches-ignore: main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -30,8 +31,9 @@ jobs:
       run: npx mix --production
 
     - name: Commit if diff
-      if: github.actor != 'github-actions'
+      if: github.actor != 'github-actions[bot]'
       run: |
+        echo 'github.actor="${{ github.actor }}"'
         git diff --exit-code && exit 0
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+on: pull_request
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve PR
+        run: gh pr review --approve "${{ github.event.pull_request.html_url }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for non-major update PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Only run build on push events to feature branches.

Print github.actor temporarily, so we can find the corret string to assure that the GitHub actions bot can never enter a push loop.

Add GitHub workflow for automatically merging dependabot PRs.